### PR TITLE
Linux shortcut

### DIFF
--- a/source/modules/shortcut.py
+++ b/source/modules/shortcut.py
@@ -36,8 +36,8 @@ def create_shortcut(folder, name):
         _exec = library_folder / folder / "blender"
         icon = library_folder / folder / "blender.svg"
         desktop = Path.home() / "Desktop"
-        name = name.replace(' ', '-')
-        dist = desktop / (name + ".desktop")
+        filename = name.replace(' ', '-')
+        dist = desktop / (filename + ".desktop")
 
         desktop_entry = \
             "[Desktop Entry]\n" + \

--- a/source/modules/shortcut.py
+++ b/source/modules/shortcut.py
@@ -42,11 +42,14 @@ def create_shortcut(folder, name):
         desktop_entry = \
             "[Desktop Entry]\n" + \
             "Name={0}\n".format(name) + \
-            "Type=Application\n" + \
-            "Comment={0}\n".format(name) + \
-            "Terminal=true\n" + \
+            "Comment=3D modeling, animation, rendering and post-production\n" + \
+            "Keywords=3d;cg;modeling;animation;painting;sculpting;texturing;video editing;video tracking;rendering;render engine;cycles;game engine;python;\n" + \
             "Icon={0}\n".format(icon.as_posix().replace(' ', r'\ ')) + \
-            "Exec=!/bin/bash {0}".format(_exec.as_posix().replace(' ', r'\ '))
+            "Terminal=false\n" + \
+            "Type=Application\n" + \
+            "Categories=Graphics;3DGraphics;\n" + \
+            "MimeType=application/x-blender;\n" + \
+            "Exec={0} %f".format(_exec.as_posix().replace(' ', r'\ '))
 
         with open(dist, 'w') as file:
             file.write(desktop_entry)


### PR DESCRIPTION
Small changes to desktop file
- Follow official Blender .desktop file conventions for uniformity (including MimeType to launch Blender when opening .blend files)
- Only use hyphenated name for .desktop file name, not for the shortcut's display name