### PR TITLE
Updated Changelog's URL

### DIFF
--- a/source/windows/main_window.py
+++ b/source/windows/main_window.py
@@ -414,7 +414,7 @@ class BlenderLauncher(QMainWindow, BaseWindow, Ui_MainWindow):
 
     def show_changelog(self):
         current_ver = re.sub(r'\D', '', self.version)
-        url = "https://dotbow.github.io/Blender-Launcher/changelog.html#{0}".format(
+        url = "https://dotbow.github.io/Blender-Launcher/changelog/#{0}".format(
             current_ver)
         webbrowser.open(url)
 


### PR DESCRIPTION
Because the old url is leading to 404 error, I decided to change it from [https://.../changelog.html#current_ver](https://dotbow.github.io/Blender-Launcher/changelog.html#1141)
to [https://.../changelo/#current_ver](https://dotbow.github.io/Blender-Launcher/changelog/#1141) to match with what I see on my browser

This' my first Pull request on GitHub. Hope It don't have any mistake 😃