### PR TITLE
Prevent None emit when blender-launcher version could not be obtained

### DIFF
--- a/source/threads/scraper.py
+++ b/source/threads/scraper.py
@@ -38,7 +38,9 @@ class Scraper(QThread):
 
     def run(self):
         self.get_download_links()
-        self.new_bl_version.emit(self.get_latest_tag())
+        latest_tag = self.get_latest_tag()
+        if latest_tag is not None:
+            self.new_bl_version.emit(self.get_latest_tag())
         self.manager.manager.clear()
         self.finished.emit()
         return


### PR DESCRIPTION
fix #238 

`Scrapper.get_latest_tag` method returns None when the version cannot be retrieved. In that case, it will not be emitted.